### PR TITLE
feature#21-(Design)-Login-Screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,11 +1,12 @@
-import { StyleSheet, View } from "react-native";
-import SignUp from "./src/views/SignUp";
-import Constants from "expo-constants";
+import { StyleSheet, View } from 'react-native';
+import SignUp from './src/views/SignUp';
+import Login from './src/views/Login';
+import Constants from 'expo-constants';
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <SignUp />
+      <Login />
     </View>
   );
 }
@@ -14,8 +15,8 @@ const styles = StyleSheet.create({
   container: {
     marginTop: Constants.statusBarHeight,
     flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/src/theme/StyleSignUp.jsx
+++ b/src/theme/StyleSignUp.jsx
@@ -1,20 +1,24 @@
-import { StyleSheet } from "react-native";
-import { COLORS } from "./colors";
+import { StyleSheet } from 'react-native';
+import { COLORS } from './colors';
 
 export const signUpStyles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
+    alignItems: 'center',
+  },
+  container2: {
+    flex: 1,
+    marginTop: 50,
   },
 });
 
 export const styleComponents = StyleSheet.create({
   containerInput: {
-    marginTop: 10,
+    marginTop: 40,
   },
   StyleDescText: {
-    position: "absolute",
-    textAlign: "justify",
+    position: 'absolute',
+    textAlign: 'justify',
     fontSize: 12,
     color: COLORS.GRAY,
     marginTop: 345,
@@ -22,11 +26,17 @@ export const styleComponents = StyleSheet.create({
   StyleHeader: {
     fontSize: 30,
     color: COLORS.BLUE,
-    fontWeight: "700",
+    fontWeight: '700',
     marginBottom: 20,
   },
+  StyleHeader2: {
+    fontSize: 30,
+    color: COLORS.BLUE,
+    fontWeight: '700',
+    marginBottom: 50,
+  },
   StyleIcon: {
-    position: "absolute",
+    position: 'absolute',
     right: 10,
     marginTop: 9,
     fontSize: 25,
@@ -38,7 +48,7 @@ export const styleComponents = StyleSheet.create({
     height: 45,
     padding: 10,
     fontSize: 20,
-    fontWeight: "600",
+    fontWeight: '600',
     marginBottom: 10,
   },
   StyleInputChange: {
@@ -48,35 +58,35 @@ export const styleComponents = StyleSheet.create({
     height: 45,
     padding: 10,
     fontSize: 20,
-    fontWeight: "600",
+    fontWeight: '600',
   },
   StyleTextInput: {
     fontSize: 20,
     color: COLORS.BLACK_GRAY,
     marginTop: 10,
     marginBottom: 5,
-    fontWeight: "300",
+    fontWeight: '300',
   },
 });
 
 export const StyleScreen = StyleSheet.create({
   OrStyle: {
     color: COLORS.LIGHT_GRAY,
-    alignSelf: 'center'
+    alignSelf: 'center',
   },
   containerTextBot: {
-    flexDirection:'row', 
-    alignSelf:'center',
-    marginTop: 10
+    flexDirection: 'row',
+    alignSelf: 'center',
+    marginTop: 10,
   },
   TextBot1: {
-    color: COLORS.GRAY, 
-    alignSelf: 'center', 
-    fontSize: 16
+    color: COLORS.GRAY,
+    alignSelf: 'center',
+    fontSize: 16,
   },
   textBot2: {
-    textDecorationLine: "underline",
+    textDecorationLine: 'underline',
     color: COLORS.BLUE,
-    fontSize: 16
-  }
+    fontSize: 16,
+  },
 });

--- a/src/views/Login.jsx
+++ b/src/views/Login.jsx
@@ -1,0 +1,49 @@
+import { View, Text, Linking } from 'react-native';
+import React, { Component } from 'react';
+import InputPass from '../components/InputPass';
+import { Checkbox } from 'react-native-paper';
+import ButtonTouch from '../components/Button';
+import Inputs from '../components/Inputs';
+import { signUpStyles, styleComponents, StyleScreen } from '../theme/StyleSignUp';
+import { StyleCheck } from '../theme/StyleCheckBox';
+import { COLORS } from '../theme/colors';
+import { Colors } from 'react-native/Libraries/NewAppScreen';
+
+export default class Login extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      checked: false,
+      checked2: false,
+    };
+  }
+  render() {
+    return (
+      <View style={signUpStyles.container2}>
+        <View>
+          <View style={styleComponents.containerInput}>
+            <Text style={styleComponents.StyleHeader2}>Login</Text>
+            <Text style={styleComponents.StyleTextInput}>Email *</Text>
+            <Inputs />
+            <Text style={styleComponents.StyleTextInput}>Password *</Text>
+            <InputPass />
+          </View>
+
+          <View>
+            <ButtonTouch text='Login' state={false} />
+            <Text style={StyleScreen.OrStyle}>or</Text>
+            <ButtonTouch
+              text='Login with Google'
+              state={false}
+              googleSign='https://aws1.discourse-cdn.com/auth0/optimized/3X/8/a/8a06490f525c8f65d4260204bc3bc7b0e1fb0ba7_2_500x500.png'
+            />
+          </View>
+          <View style={StyleScreen.containerTextBot}>
+            <Text style={StyleScreen.TextBot1}>Don't have an account? </Text>
+            <Text style={StyleScreen.textBot2}>Register</Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
# Description
### What?
- Make the design for the login page of the application using the SignUp screen as reference and reusing components. See Initializing the React Native project #21 for more information
### Why
- To grant the users the possibility to access the application if they already have an account in the system. See Initializing the React Native project #21 for more information.

## Testing

- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- then you can initialize with an android emulator or via web
```npm start```

## Screenshots

| Proposed design   |      Successful design      |
|----------|:-------------:|
| ![login](https://user-images.githubusercontent.com/54423116/213579039-82e4ce23-9687-4a8f-8a14-5129f00feb1c.PNG) | ![loginMade](https://user-images.githubusercontent.com/54423116/213593059-99005e76-c28b-42e7-9aa2-ecd7c304ec85.PNG) |