### PR TITLE
feature#27-Navigation-between-screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,23 +1,11 @@
 import { StyleSheet, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
 import SignUp from './src/views/SignUp';
 import Login from './src/views/Login';
 import Constants from 'expo-constants';
 import MyFlights from './src/views/MyFlights';
+import Navigation from './src/navigation/index';
 
 export default function App() {
-  return (
-    <View style={styles.container}>
-      <MyFlights />
-    </View>
-  );
+  return <Navigation />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: Constants.statusBarHeight,
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from "react";
-import { Text, TouchableOpacity, View, Image } from "react-native";
-import { styleButton } from "../theme/StyleButton";
+import React, { Component } from 'react';
+import { Text, TouchableOpacity, View, Image } from 'react-native';
+import { styleButton } from '../theme/StyleButton';
 
 export default class ButtonTouch extends Component {
   constructor(props) {
@@ -9,15 +9,13 @@ export default class ButtonTouch extends Component {
   render() {
     return (
       <TouchableOpacity
-        style={
-          this.props.state ? styleButton.container : styleButton.containerGray
-        }
+        style={this.props.state ? styleButton.container : styleButton.containerGray}
+        onPress={() => {
+          this.props.navegation.navigate(this.props.screenNav);
+        }}
       >
         <View style={styleButton.itemsAlign}>
-          <Image
-            source={{ uri: this.props.googleSign }}
-            style={styleButton.imgStyle}
-          />
+          <Image source={{ uri: this.props.googleSign }} style={styleButton.imgStyle} />
           <Text style={styleButton.textStyle}> {this.props.text} </Text>
         </View>
       </TouchableOpacity>

--- a/src/navigation/index.jsx
+++ b/src/navigation/index.jsx
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import Login from '../views/Login';
+import SignUp from '../views/SignUp';
+import MyFlights from '../views/MyFlights';
+
+const Stack = createNativeStackNavigator();
+
+export default class Navigation extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator
+          initialRouteName='Login'
+          screenOptions={{
+            headerShown: false,
+          }}
+        >
+          <Stack.Screen name='Login' component={Login} />
+
+          <Stack.Screen name='SignUp' component={SignUp} />
+
+          <Stack.Screen name='MyFlights' component={MyFlights} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  }
+}

--- a/src/theme/StyleCardFlight.jsx
+++ b/src/theme/StyleCardFlight.jsx
@@ -1,4 +1,15 @@
 import { StyleSheet } from 'react-native';
+import Constants from 'expo-constants';
+
+export const stylesContainer = StyleSheet.create({
+  container: {
+    marginTop: Constants.statusBarHeight,
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
 
 export const stylesCards = StyleSheet.create({
   containerCards: {

--- a/src/theme/StyleSignUp.jsx
+++ b/src/theme/StyleSignUp.jsx
@@ -8,7 +8,9 @@ export const signUpStyles = StyleSheet.create({
   },
   container2: {
     flex: 1,
-    marginTop: 50,
+    marginTop: -20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -33,7 +35,7 @@ export const styleComponents = StyleSheet.create({
     fontSize: 30,
     color: COLORS.BLUE,
     fontWeight: '700',
-    marginBottom: 50,
+    marginBottom: 20,
   },
   StyleIcon: {
     position: 'absolute',

--- a/src/views/Login.jsx
+++ b/src/views/Login.jsx
@@ -30,7 +30,12 @@ export default class Login extends Component {
           </View>
 
           <View>
-            <ButtonTouch text='Login' state={false} />
+            <ButtonTouch
+              text='Login'
+              state={false}
+              screenNav='MyFlights'
+              navegation={this.props.navigation}
+            />
             <Text style={StyleScreen.OrStyle}>or</Text>
             <ButtonTouch
               text='Login with Google'
@@ -40,7 +45,14 @@ export default class Login extends Component {
           </View>
           <View style={StyleScreen.containerTextBot}>
             <Text style={StyleScreen.TextBot1}>Don't have an account? </Text>
-            <Text style={StyleScreen.textBot2}>Register</Text>
+            <Text
+              style={StyleScreen.textBot2}
+              onPress={() => {
+                this.props.navigation.navigate('SignUp');
+              }}
+            >
+              Register
+            </Text>
           </View>
         </View>
       </View>

--- a/src/views/MyFlights.jsx
+++ b/src/views/MyFlights.jsx
@@ -5,99 +5,102 @@ import CardFlight from '../components/CardFlight';
 import FloatingButton from '../components/FloatingButton';
 import { StyleFloatingButton } from '../theme/StyleFloatingButton';
 import { styleComponents } from '../theme/StyleSignUp';
+import { stylesContainer } from '../theme/StyleCardFlight';
 
 export default class MyFlights extends Component {
   render() {
     return (
-      <View style={StyleFloatingButton.container}>
-        <Text style={styleComponents.StyleHeader}>My flights</Text>
-        <ScrollView showsVerticalScrollIndicator={false}>
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-          <CardFlight
-            data={{
-              departure: {
-                country: 'Serbia',
-                countryCode: 'BEG',
-              },
-              arrival: {
-                country: 'Netherlands',
-                countryCode: 'AMS',
-              },
-              date: 'September 3, 2020',
-              passengers: '2 passengers',
-            }}
-          />
-        </ScrollView>
-        <FloatingButton />
+      <View style={stylesContainer.container}>
+        <View style={StyleFloatingButton.container}>
+          <Text style={styleComponents.StyleHeader}>My flights</Text>
+          <ScrollView showsVerticalScrollIndicator={false}>
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+            <CardFlight
+              data={{
+                departure: {
+                  country: 'Serbia',
+                  countryCode: 'BEG',
+                },
+                arrival: {
+                  country: 'Netherlands',
+                  countryCode: 'AMS',
+                },
+                date: 'September 3, 2020',
+                passengers: '2 passengers',
+              }}
+            />
+          </ScrollView>
+          <FloatingButton />
+        </View>
       </View>
     );
   }

--- a/src/views/SignUp.jsx
+++ b/src/views/SignUp.jsx
@@ -1,13 +1,13 @@
-import { View, Text, Linking } from "react-native";
-import React, { Component } from "react";
-import InputPass from "../components/InputPass";
-import { Checkbox } from "react-native-paper";
-import ButtonTouch from "../components/Button";
-import Inputs from "../components/Inputs";
-import { signUpStyles, styleComponents, StyleScreen} from "../theme/StyleSignUp";
-import { StyleCheck } from "../theme/StyleCheckBox";
-import { COLORS } from "../theme/colors";
-import { Colors } from "react-native/Libraries/NewAppScreen";
+import { View, Text, Linking } from 'react-native';
+import React, { Component } from 'react';
+import InputPass from '../components/InputPass';
+import { Checkbox } from 'react-native-paper';
+import ButtonTouch from '../components/Button';
+import Inputs from '../components/Inputs';
+import { signUpStyles, styleComponents, StyleScreen } from '../theme/StyleSignUp';
+import { StyleCheck } from '../theme/StyleCheckBox';
+import { COLORS } from '../theme/colors';
+import { Colors } from 'react-native/Libraries/NewAppScreen';
 
 export default class SignUp extends Component {
   constructor(props) {
@@ -30,14 +30,13 @@ export default class SignUp extends Component {
             <Text style={styleComponents.StyleTextInput}>Password *</Text>
             <InputPass />
             <Text style={styleComponents.StyleDescText}>
-              Use 8 or more characters with a mix of letters, numbers, and
-              symbols
+              Use 8 or more characters with a mix of letters, numbers, and symbols
             </Text>
           </View>
 
           <View style={StyleCheck.container}>
             <Checkbox
-              status={this.state.checked ? "checked" : "unchecked"}
+              status={this.state.checked ? 'checked' : 'unchecked'}
               color={COLORS.BLUE}
               onPress={() => {
                 this.setState({ checked: !this.state.checked });
@@ -47,14 +46,14 @@ export default class SignUp extends Component {
               <Text style={StyleCheck.TextGray}>I agree to the </Text>
               <Text
                 style={StyleCheck.TextSubrayado}
-                onPress={() => Linking.openURL("https://www.google.com/")}
+                onPress={() => Linking.openURL('https://www.google.com/')}
               >
                 Terms
               </Text>
               <Text style={StyleCheck.TextGray}> and </Text>
               <Text
                 style={StyleCheck.TextSubrayado}
-                onPress={() => Linking.openURL("https://www.google.com/")}
+                onPress={() => Linking.openURL('https://www.google.com/')}
               >
                 Privacy Policy
               </Text>
@@ -64,31 +63,39 @@ export default class SignUp extends Component {
 
           <View style={StyleCheck.containerCheck2}>
             <Checkbox
-              status={this.state.checked2 ? "checked" : "unchecked"}
+              status={this.state.checked2 ? 'checked' : 'unchecked'}
               color={COLORS.BLUE}
               onPress={() => {
                 this.setState({ checked2: !this.state.checked2 });
               }}
             />
             <Text style={StyleCheck.Textcheck}>
-              <Text style={StyleCheck.TextGray}>
-                Subscribe for select product updates
-              </Text>
+              <Text style={StyleCheck.TextGray}>Subscribe for select product updates</Text>
             </Text>
           </View>
 
           <View>
-            <ButtonTouch text="Sign Up" state={false} />
+            <ButtonTouch
+              text='Sign Up'
+              state={false}
+              screenNav='Login'
+              navegation={this.props.navigation}
+            />
             <Text style={StyleScreen.OrStyle}>or</Text>
             <ButtonTouch
-              text="Sign Up with Google"
+              text='Sign Up with Google'
               state={false}
-              googleSign="https://aws1.discourse-cdn.com/auth0/optimized/3X/8/a/8a06490f525c8f65d4260204bc3bc7b0e1fb0ba7_2_500x500.png"
+              googleSign='https://aws1.discourse-cdn.com/auth0/optimized/3X/8/a/8a06490f525c8f65d4260204bc3bc7b0e1fb0ba7_2_500x500.png'
             />
           </View>
           <View style={StyleScreen.containerTextBot}>
             <Text style={StyleScreen.TextBot1}>Already have an account? </Text>
-            <Text style={StyleScreen.textBot2}>Login</Text>
+            <Text
+              style={StyleScreen.textBot2}
+              onPress={() => this.props.navigation.navigate('Login')}
+            >
+              Login
+            </Text>
           </View>
         </View>
       </View>


### PR DESCRIPTION
Co-authored-by: victordoom <23017227+victordoom@users.noreply.github.com>
Co-authored-by: Leonardo-Aguirre-Ponce <Leonardo-Aguirre-Ponce@users.noreply.github.com>
Co-authored-by: Rodrigo Aparicio <Zuack55@users.noreply.github.com>

# Description
### What?
- We made the connection between the sign up and login screens and my flights. See Initializing the React Native project #27  for more information
### Why
- To enable users to navigate between all screens. See Initializing the React Native project #27 for more information.

## Testing

- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- then you can initialize with an android emulator or via web
```npm start```

## Screenshots

| Changes applied |
|----------|
| ![image](https://user-images.githubusercontent.com/72171210/214448654-c58660e3-a8b7-498b-98f3-f37940c1a34b.png) |